### PR TITLE
Adding two scripts

### DIFF
--- a/mikemergr.R
+++ b/mikemergr.R
@@ -1,0 +1,47 @@
+library(DBI)
+library(RSQLite)
+library(nflfastR)
+library(puntr)
+library(tidyverse)
+library(gsisdecoder)
+
+# Standard code chunk we use to get up-to-date data #####
+update_db()
+connection <- dbConnect(SQLite(), "./pbp_db")
+pbp <- tbl(connection, "nflfastR_pbp")
+extra_cols <- pbp %>%
+  filter(season==2021) %>%
+  filter(week==1) %>%
+  collect %>%
+  select(-c(play_id, game_id)) %>%
+  colnames()
+
+punts <- pbp %>%
+  filter(punt_attempt==1) %>%
+  filter(season %in% 2019:2021) %>%
+  collect() %>%
+  trust_the_process() %>%
+  calculate_all() %>%
+  filter(season == 2021)
+
+dbDisconnect(connection)
+
+# Grab game_ids #####
+game_ids <- fast_scraper_schedules(2021) %>%
+  # filter down to what you want
+  filter(week == 1) %>%
+  filter(weekday == "Thursday") %>%
+
+  # select only the game_ids
+  select(game_id)
+
+# Merge Mike data into pbp #####
+mike <- game_ids %>%
+  import_mike() %>%
+  #
+  select(-all_of(extra_cols))
+
+punts_mike <- punts %>%
+  left_join(mike, by = c('game_id', 'play_id'))
+
+

--- a/mikescrapr.R
+++ b/mikescrapr.R
@@ -1,0 +1,36 @@
+library(nflfastR)
+library(puntr)
+library(tidyverse)
+library(glue)
+
+# This is very similar to puntr::import_punts()
+import_mike <- function(game_ids, local = FALSE, path = NULL) {
+  if(local == TRUE) {
+    message(glue("Importing locally from {path}"))
+    punts <- game_ids %>%
+      purrr::map_df(import_local_csv, path)
+    return(punts)
+  } else if(local == FALSE) {
+    message("Importing from https://raw.githubusercontent.com/mlounsberry/Punt-Charting-2021/main/Punt-Data/
+    For faster import, clone this repo locally and use local = TRUE")
+    punts <- game_ids %>%
+      purrr::map_df(import_one_csv, 'https://raw.githubusercontent.com/mlounsberry/Punt-Charting-2021/main/Punt-Data/')
+    return(punts)
+  } else { stop("'local' must be TRUE or FALSE")}
+
+}
+
+# Helper function for a single file, pulling from URL
+import_one_csv <- function(game_id, url) {
+  pbp <- glue::glue('{url}{game_id}.csv') %>%
+    url() %>%
+    read_csv(show_col_types=FALSE)
+  return(pbp)
+}
+
+# Helper function for a single file, downloaded locally
+import_local_csv <- function(game_id, path) {
+  pbp <- glue::glue('{path}/Punt-Charting-2021/Punt-Data/{game_id}.csv') %>%
+    read_csv(show_col_types=FALSE)
+  return(pbp)
+}


### PR DESCRIPTION
Running these two in sequence (`mikescrapr.R`, then `mikemergr.R`) should give you a dataframe with all of the standard play-by-play data, the Puntalytics metrics, and the new data. Would be easy enough to adjust this for whatever the new file names become; once the workflow has stabilized (no rush!!!) I'll wrap the contents of these two scripts into a `puntr` function. Good stuff!